### PR TITLE
Rename creators.js import to creators

### DIFF
--- a/src/background/commands/mkdir.js
+++ b/src/background/commands/mkdir.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {createDirectory} from 'creators.js';
+import {createDirectory} from 'creators';
 import { getDirectory } from 'utils';
 
 import type { StoreState } from 'types';

--- a/src/background/commands/window/split.js
+++ b/src/background/commands/window/split.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { createWindow } from 'creators.js';
+import { createWindow } from 'creators';
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/workspace.js
+++ b/src/background/commands/workspace.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { createWorkspace } from 'creators.js';
+import { createWorkspace } from 'creators';
 
 import type { StoreState } from 'types';
 

--- a/src/background/reducers/index.js
+++ b/src/background/reducers/index.js
@@ -3,7 +3,7 @@
 import u from 'updeep';
 import { executeCommand } from 'background/commands';
 import { clear, save } from 'background/storage';
-import { createDirectory, createFile, createWorkspace } from 'creators.js';
+import { createDirectory, createFile, createWorkspace } from 'creators';
 import {
     findWindow,
     getBorderingBottom,

--- a/src/background/scripts/index.js
+++ b/src/background/scripts/index.js
@@ -2,7 +2,7 @@
 
 import { isCommand } from 'background/commands';
 import store from 'background/store';
-import { createFile, createTerminal, createWindow } from 'creators.js';
+import { createFile, createTerminal, createWindow } from 'creators';
 import { findWindow, getDirectory, getFile, getPath } from 'utils';
 
 import type { Directory, File, Script as ScriptType, Window } from 'types';

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import setupFile from 'background/setup';
-import { createDirectory, createFile, createWorkspace } from 'creators.js';
+import { createDirectory, createFile, createWorkspace } from 'creators';
 
 import type { StorageState, StoreState } from 'types';
 

--- a/src/mercury/store.js
+++ b/src/mercury/store.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { createDirectory } from 'creators.js';
+import { createDirectory } from 'creators';
 import reducer from 'mercury/reducer';
 import { createStore } from 'redux';
 


### PR DESCRIPTION
Cleaning up import name from previous switch (`constants.js` to `creators.js`)