### PR TITLE
Don't use spread operator in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,11 +44,12 @@ const config = {
     },
     plugins: [
         new webpack.DefinePlugin(
-            Object.entries(Constants).reduce(
-                (acc, [key, val]) => ({
-                    ...acc,
-                    ['Constants.' + key]: JSON.stringify(val)
-                }),
+            Object.keys(Constants).reduce(
+                (acc, key) => Object.assign(acc,
+                    {
+                        ['Constants.' + key]: JSON.stringify(Constants[key])
+                    }
+                ),
                 {}
             )
         ),


### PR DESCRIPTION
Babel doesn't run on this config.js so `...` is not supported on a lot of node versions (only on v10 I think).

