### PR TITLE
Fix flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,3 +14,8 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 module.ignore_non_literal_requires=true
 
 [strict]
+nonstrict-import
+; unclear-type
+unsafe-getters-setters
+untyped-import
+untyped-type-import

--- a/.flowconfig
+++ b/.flowconfig
@@ -9,7 +9,7 @@ node_modules/flow-interfaces-chrome/interfaces/
 
 [options]
 module.system.node.resolve_dirname=node_modules
-module.system.node.resolve_dirname=src
+module.system.node.resolve_dirname=./src
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 module.ignore_non_literal_requires=true
 

--- a/flow-typed/mercurywm.js
+++ b/flow-typed/mercurywm.js
@@ -1,0 +1,35 @@
+// @flow
+// This contains type information for any global variables
+// added through webpack.
+
+// To add another constant, make sure to add the value in `src/constants.js`.
+// If it is a static variable, add its value to this type. Otherwise, add the
+// type of the variable instead (number, string, etc.)
+
+declare var Constants: {|
+    NAME: 'Mercury WM',
+    VERSION: string,
+    STATE_KEY: 'state',
+    DIR_TYPE: 'dir',
+    FILE_TYPE: 'file',
+    EXE_TYPE: 'exe',
+    MERCURYWM_URL: string,
+    MERCURYWM_ORIGIN: string,
+    MERCURYWM_CONTENT_URL: string,
+
+    // KEY CODES
+    KEY_LEFT_ARROW: 37,
+    KEY_UP_ARROW: 38,
+    KEY_RIGHT_ARROW: 39,
+    KEY_DOWN_ARROW: 40,
+    KEY_ENTER: 13,
+    KEY_BACKSPACE: 8,
+    KEY_DELETE: 46,
+    KEY_TAB: 9
+|};
+
+declare var PRODUCTION: boolean;
+
+declare module "updeep" {
+    declare module.exports: <T>(update: Object, object: T) => T;
+}

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,0 +1,261 @@
+// flow-typed signature: 502cfd4f5e95c6308f747cdf16dc93ce
+// flow-typed version: 1751d5bf0a/react-redux_v5.x.x/flow_>=v0.68.0
+
+declare module "react-redux" {
+  import type { ComponentType, ElementConfig } from 'react';
+
+  // These types are copied directly from the redux libdef. Importing them in
+  // this libdef causes a loss in type coverage.
+  declare type DispatchAPI<A> = (action: A) => A;
+  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Store<S, A, D = Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
+
+  declare export class Provider<S, A, D> extends React$Component<{
+    +store: Store<S, A, D>,
+    children?: any
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string
+  ): Provider<*, *, *>;
+
+  /*
+
+  S = State
+  A = Action
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  MDP = Map dispatch to props object
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
+  */
+
+  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+
+  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+
+  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: MP
+  ) => RMP;
+
+  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
+    pure?: boolean,
+    withRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
+    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
+    storeKey?: string
+  |};
+
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch?: Dispatch<*>}>;
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    withRef?: boolean,
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    withRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+  };
+
+  declare type SelectorFactory<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object
+  > = (dispatch: Dispatch<A>, factoryOptions: SelectorFactoryOptions<Com> & EFO) =>
+      MapStateToProps<S, OP, CP>;
+
+  declare export function connectAdvanced<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: {[_: $Keys<Com>]: any}
+    >(
+    selectorFactory: SelectorFactory<Com, A, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => ComponentType<OP> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    SP: Object,
+    RSP: Object,
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
+    ST: {[_: $Keys<Com>]: any}
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<CP & SP> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    ST: {[_: $Keys<Com>]: any}
+    >(
+    mapStateToProps?: null,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
+  ): (component: Com) => ComponentType<CP & SP & DP> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    OP: Object,
+    DP: Object,
+    PR: Object,
+    CP: $Diff<ElementConfig<Com>, DP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps?: null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
+  ): (Com) => ComponentType<CP & OP>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    MDP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps?: null,
+    mapDispatchToProps: MDP
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    SP: Object,
+    RSP: Object,
+    MDP: Object,
+    CP: $Diff<ElementConfig<Com>, RSP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: MDP
+  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MDP: Object,
+    MP: Object,
+    RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: MDP,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
+
+  declare export function connect<Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
+    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
+
+  declare export function connect<Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MDP: Object,
+    MP: Object,
+    RMP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
+    >(
+    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MDP,
+    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+  };
+}

--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,0 +1,59 @@
+// flow-typed signature: cca4916b0213065533df8335c3285a4a
+// flow-typed version: cab04034e7/redux_v3.x.x/flow_>=v0.55.x
+
+declare module 'redux' {
+
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> =
+    (api: MiddlewareAPI<S, A, D>) =>
+      (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
+
+  declare export function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
+  declare export function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
+
+  declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
         "babel-preset-env": "^1.6.0",
         "babel-preset-react": "^6.24.1",
         "babel-preset-stage-2": "^6.24.1",
+        "cross-env": "^5.1.4",
+        "flow-bin": "^0.85.0",
         "flow-interfaces-chrome": "^0.4.0",
+        "flow-typed": "^2.5.1",
         "react": "^15.6.1",
         "react-dom": "^15.6.1",
         "react-redux": "^5.0.6",
@@ -28,7 +31,6 @@
         "remove-flow-types-loader": "^1.1.0",
         "uglify-js": "^3.1.5",
         "updeep": "^1.0.0",
-        "webpack": "^3.5.2",
-        "cross-env": "^5.1.4"
+        "webpack": "^3.5.2"
     }
 }

--- a/src/background/commands/backup.js
+++ b/src/background/commands/backup.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/cat.js
+++ b/src/background/commands/cat.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { getFile } from 'utils';
 

--- a/src/background/commands/cd.js
+++ b/src/background/commands/cd.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { getPath, getDirectory } from 'utils';
 

--- a/src/background/commands/env.js
+++ b/src/background/commands/env.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/index.js
+++ b/src/background/commands/index.js
@@ -82,7 +82,7 @@ export function isCommand(name: string) {
     return names.find(n => n === name);
 }
 
-export function executeCommand(state: StoreState, input: string) {
+export function executeCommand(state: StoreState, input: string): StoreState {
     if (input === '') return state;
 
     const [name, ...params] = parseInput(input);
@@ -96,7 +96,7 @@ export function executeCommand(state: StoreState, input: string) {
         return state;
     } else if (isCommand(name)) {
         return require('./' + name).default.call(command, state, params);
-    } else if (name !== undefined) {
+    } else {
         // $FlowFixMe: command can mutate state
         command.terminal.running = true;
         return state;

--- a/src/background/commands/index.js
+++ b/src/background/commands/index.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { clear } from 'background/storage';
 import { findWindow } from 'utils';

--- a/src/background/commands/info.js
+++ b/src/background/commands/info.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/kill.js
+++ b/src/background/commands/kill.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/ls.js
+++ b/src/background/commands/ls.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { getDirectory } from 'utils';
 

--- a/src/background/commands/mkdir.js
+++ b/src/background/commands/mkdir.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import {createDirectory} from 'creators';
 import { getDirectory } from 'utils';

--- a/src/background/commands/reload.js
+++ b/src/background/commands/reload.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/render.js
+++ b/src/background/commands/render.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { getFile } from 'utils';
 

--- a/src/background/commands/rm.js
+++ b/src/background/commands/rm.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { getDirectory, getFile, getPath } from 'utils';
 

--- a/src/background/commands/window/index.js
+++ b/src/background/commands/window/index.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import merge from './merge';
 import shift from './shift';

--- a/src/background/commands/window/merge.js
+++ b/src/background/commands/window/merge.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { StoreState } from 'types';
 

--- a/src/background/commands/window/shift.js
+++ b/src/background/commands/window/shift.js
@@ -35,9 +35,11 @@ export default function shift(state: StoreState, params: Array<string>) {
     result = getBorderingRight(this.windowIndex, windows);
   } else if (params[0] === 'top') {
     result = getBorderingTop(this.windowIndex, windows);
-  } else if (params[0] === 'bottom') {
+  } else {
+    // params[0] is guaranteed to be 'bottom' by now
     result = getBorderingBottom(this.windowIndex, windows);
   }
+
   if (result.length !== 0) {
     const change =
       params[1] === '+' ? 1 : params[1] === '-' ? -1 : parseInt(params[1]);

--- a/src/background/commands/window/shift.js
+++ b/src/background/commands/window/shift.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import {
   getBorderingBottom,

--- a/src/background/commands/window/split.js
+++ b/src/background/commands/window/split.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { createWindow } from 'creators';
 

--- a/src/background/commands/workspace.js
+++ b/src/background/commands/workspace.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { createWorkspace } from 'creators';
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import executeScript from './scripts';
 import { clear } from './storage';

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -16,6 +16,8 @@ window.reset = () => {
 console.log('MercuryWM background running');
 
 chrome.runtime.onConnect.addListener(port => {
+    if (!port) return;
+
     console.assert(port.name === 'mercurywm');
     console.log('connected');
     port.postMessage('connected');
@@ -34,7 +36,8 @@ chrome.runtime.onConnect.addListener(port => {
             const newState = store.getState();
             // Only handle async script if store determines it is (and sets
             //   status to running)
-            if (getCurrentWindow(newState).terminal.running) {
+            const currWindow = getCurrentWindow(newState);
+            if (currWindow && currWindow.terminal.running) {
                 // Run the script async
                 executeScript(newState.selectedWindow, action.text);
             }

--- a/src/background/reducers/index.js
+++ b/src/background/reducers/index.js
@@ -1,8 +1,8 @@
-/* @flow */
+/* @flow strict */
 
 import u from 'updeep';
 import { executeCommand } from 'background/commands';
-import { clear, save } from 'background/storage';
+import { clear, save, initialState } from 'background/storage';
 import { createDirectory, createFile, createWorkspace } from 'creators';
 import {
     findWindow,
@@ -390,7 +390,7 @@ const rootReducer = function(state: StoreState, action: Action): StoreState {
     }
 };
 
-const saveWrapper = function(state: StoreState, action: Action) {
+const saveWrapper = function(state: StoreState = initialState, action: Action) {
     const newState = rootReducer(state, action);
     save(newState);
     return newState;

--- a/src/background/scripts/async.js
+++ b/src/background/scripts/async.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Script } from 'types';
 

--- a/src/background/scripts/edit.js
+++ b/src/background/scripts/edit.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Script } from 'types';
 

--- a/src/background/scripts/index.js
+++ b/src/background/scripts/index.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { isCommand } from 'background/commands';
 import store from 'background/store';

--- a/src/background/scripts/yum.js
+++ b/src/background/scripts/yum.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Script } from 'types';
 

--- a/src/background/setup.js
+++ b/src/background/setup.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 let script: {
     output: string => void,

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import setupFile from 'background/setup';
 import { createDirectory, createFile, createWorkspace } from 'creators';

--- a/src/background/store.js
+++ b/src/background/store.js
@@ -1,10 +1,10 @@
-/* @flow */
+/* @flow strict */
 
 import { createStore } from 'redux';
 import Storage from 'background/storage';
 import reducers from 'background/reducers';
 
-import type { Store, Action } from 'types';
+import type { Store } from 'types';
 
 const store: Store = createStore(reducers, Storage.initialState);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,11 @@
+/* Constants */
+
+// This file is used directly by webpack, so cannot contain any flow or
+// ES features that Node doesn't support.
+
 const packageData = require('../package.json');
 
 const MERCURY_BASE_URL = 'https://wheel-org.github.io/';
-
-/* Constants */
 
 // To add another constant, make sure to add the type in
 // `flow-typed/mercurywm.js`. If it is a static variable,

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,12 @@ const packageData = require('../package.json');
 const MERCURY_BASE_URL = 'https://wheel-org.github.io/';
 
 /* Constants */
+
+// To add another constant, make sure to add the type in
+// `flow-typed/mercurywm.js`. If it is a static variable,
+// add its value to this type. Otherwise, add the
+// type of the variable instead (number, string, etc.)
+
 const Constants = {
     NAME: 'Mercury WM',
     VERSION: packageData.version,

--- a/src/creators.js
+++ b/src/creators.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Directory, File, Terminal, Window, Workspace } from 'types';
 

--- a/src/mercury/background.js
+++ b/src/mercury/background.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Action } from 'types';
 

--- a/src/mercury/components/app.jsx
+++ b/src/mercury/components/app.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -49,4 +49,6 @@ const mapStateToProps = (state: StoreState): Props => {
     };
 };
 
-export default connect(mapStateToProps)(App);
+const ConnectedComp: React.ComponentType<{||}> = connect(mapStateToProps)(App);
+
+export default ConnectedComp;

--- a/src/mercury/components/bottombar.jsx
+++ b/src/mercury/components/bottombar.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -15,14 +15,14 @@ type DispatchProps = {|
   +onClick: number => void
 |};
 
-type Props = {| ...StateProps, ...DispatchProps |};
+type Props = StateProps & DispatchProps;
 
 const BottomBar = ({
   numWorkspaces,
   selectedWorkspace,
   username,
   onClick
-}: Props) => {
+}: Props): React.Node => {
   const buttons = [];
   for (let i = 0; i < numWorkspaces; i++) {
     buttons.push(
@@ -59,4 +59,9 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   }
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(BottomBar);
+const ConnectedComp: React.ComponentType<{||}> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(BottomBar);
+
+export default ConnectedComp;

--- a/src/mercury/components/loading.jsx
+++ b/src/mercury/components/loading.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 

--- a/src/mercury/components/root.jsx
+++ b/src/mercury/components/root.jsx
@@ -1,4 +1,4 @@
-/* @flow
+/* @flow strict
  * root.jsx
  * Renders the app when data is loaded, or shows the loading page
  * Handles global key listeners and iframe message listeners
@@ -30,7 +30,7 @@ type DispatchProps = {|
     +createOrModifyFile: (string, string) => void
 |};
 
-type Props = {| ...StateProps, ...DispatchProps |};
+type Props = StateProps & DispatchProps;
 
 class Root extends React.Component<Props> {
     componentWillMount() {
@@ -127,4 +127,9 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
         })
 });
 
-module.exports = connect(mapStateToProps, mapDispatchToProps)(Root);
+const ConnectedComp: React.ComponentType<{||}> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Root);
+
+export default ConnectedComp;

--- a/src/mercury/components/terminal-link.jsx
+++ b/src/mercury/components/terminal-link.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -25,12 +25,12 @@ type DispatchProps = {|
     +executeCommand: string => void
 |};
 
-type Props = {|
+type PassedProps = {|
     terminal: TerminalType,
     selected: boolean,
-    ...StateProps,
-    ...DispatchProps
 |};
+
+type Props = PassedProps & StateProps & DispatchProps;
 
 type State = {|
     historyIndex: number,
@@ -289,4 +289,9 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
     };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(TerminalLink);
+const ConnectedComp: React.ComponentType<PassedProps> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TerminalLink);
+
+export default ConnectedComp;

--- a/src/mercury/components/terminal.jsx
+++ b/src/mercury/components/terminal.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 

--- a/src/mercury/components/window.jsx
+++ b/src/mercury/components/window.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -15,13 +15,13 @@ type DispatchProps = {|
   +onClick: number => void
 |};
 
-type Props = {|
+type PassedProps =  {|
   +window: WindowType,
   +index: number,
   +selected: boolean,
-  ...StateProps,
-  ...DispatchProps
 |};
+
+type Props = PassedProps & StateProps & DispatchProps;
 
 class Window extends React.Component<Props> {
   cacheParamValue = Date.now();
@@ -128,4 +128,9 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   }
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(Window);
+const ConnectedComp: React.ComponentType<PassedProps> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Window);
+
+export default ConnectedComp;

--- a/src/mercury/components/workspace.jsx
+++ b/src/mercury/components/workspace.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -11,10 +11,11 @@ type StateProps = {|
   +currentWindowId: number
 |};
 
-type Props = {|
+type PassedProps = {|
   +workspace: WorkspaceType,
-  ...StateProps
-|};
+|}
+
+type Props = PassedProps & StateProps;
 
 const Workspace = ({ workspace, currentWindowId }: Props) => {
   const windows = [];
@@ -35,4 +36,8 @@ const mapStateToProps = (state: StoreState): StateProps => ({
   currentWindowId: state.selectedWindow
 });
 
-export default connect(mapStateToProps)(Workspace);
+const ConnectedComp: React.ComponentType<PassedProps> = connect(
+  mapStateToProps
+)(Workspace);
+
+export default ConnectedComp;

--- a/src/mercury/index.jsx
+++ b/src/mercury/index.jsx
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import * as React from 'react';
 import { render } from 'react-dom';

--- a/src/mercury/reducer.js
+++ b/src/mercury/reducer.js
@@ -1,10 +1,14 @@
-/* @flow */
+/* @flow strict */
 
 import dispatchToBackground from './background';
+import { initialState } from './store';
 
 import type { StoreState, Action } from 'types';
 
-const reducer = (state: StoreState, action: Action) => {
+const reducer = (
+  state: StoreState = initialState,
+  action: Action
+): StoreState => {
   if (action.type === 'LOAD_STORAGE') {
     return { ...action.data };
   }

--- a/src/mercury/store.js
+++ b/src/mercury/store.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import { createDirectory } from 'creators';
 import reducer from 'mercury/reducer';
@@ -7,7 +7,7 @@ import { createStore } from 'redux';
 import type { StorageState, Store } from 'types';
 
 // Not actual valid state since real state will be taken from storage
-const initialState: StorageState = {
+const defaultStateObject: StorageState = {
   [Constants.STATE_KEY]: {
     loaded: false,
     workspaces: [],
@@ -20,7 +20,7 @@ const initialState: StorageState = {
   }
 };
 
-const store: Store = createStore(reducer, initialState[Constants.STATE_KEY]);
+const store: Store = createStore(reducer, defaultStateObject[Constants.STATE_KEY]);
 
 chrome.storage.local.get(Constants.STATE_KEY, (data: StorageState) => {
   store.dispatch({
@@ -39,3 +39,4 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 });
 
 export default store;
+export const initialState = defaultStateObject[Constants.STATE_KEY];

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,6 +1,6 @@
-/* @flow */
+/* @flow strict */
 
-import type { ExtensionMessage, ExtensionResponse } from 'types';
+import type { ExtensionMessage, ExtensionResponse } from "types";
 
 const fileRequestCallback: { [string]: (string) => void } = {};
 const qp: { [string]: string } = getQueryParams(document.location.search);
@@ -9,7 +9,7 @@ const env: { [string]: string } = JSON.parse(qp.env);
 const params: string[] = JSON.parse(qp.params);
 console.log({ runningCommand, workingDirectory, cache, id, env, params });
 
-const content = document.getElementById('content');
+const content = document.getElementById("content");
 if (content && params[0]) {
   getFile(params[0], htmlFile => {
     console.log(htmlFile);
@@ -26,30 +26,32 @@ if (content && params[0]) {
 }
 
 function getFile(path: string, callback: string => void) {
-  if (path.startsWith('~')) path = workingDirectory + '/' + path;
-  fileRequestCallback[path] = callback;
+  const absolutePath = path.startsWith("~")
+    ? workingDirectory + "/" + path
+    : path;
+  fileRequestCallback[absolutePath] = callback;
   sendMessage({
-    type: 'requestFile',
-    path
+    type: "requestFile",
+    path: absolutePath
   });
 }
 
 function writeFile(path: string, content: string) {
   sendMessage({
-    type: 'writeFile',
+    type: "writeFile",
     path,
     content
   });
 }
 
 function getEnv(key: string) {
-  return env[key] || '';
+  return env[key] || "";
 }
 
 function setEnv(key: string, value: string) {
   env[key] = value;
   sendMessage({
-    type: 'env',
+    type: "env",
     key,
     value
   });
@@ -58,26 +60,26 @@ function setEnv(key: string, value: string) {
 // Exit render
 function done() {
   sendMessage({
-    type: 'done',
+    type: "done",
     id
   });
 }
 
 function sendMessage(msg: ExtensionMessage) {
-  parent.postMessage(JSON.stringify(msg), '*');
+  parent.postMessage(JSON.stringify(msg), "*");
 }
 
 window.onload = function() {
-  window.addEventListener('keydown', function(e) {
+  window.addEventListener("keydown", function(e) {
     if (e.ctrlKey && e.keyCode === 67) {
       // Quit extension on Ctrl+C
       done();
     }
   });
 
-  window.addEventListener('message', event => {
+  window.addEventListener("message", event => {
     const message: ExtensionResponse = JSON.parse(event.data);
-    if (message.type === 'file') {
+    if (message.type === "file") {
       if (fileRequestCallback[message.path]) {
         fileRequestCallback[message.path](message.contents);
         delete fileRequestCallback[message.path];
@@ -85,7 +87,7 @@ window.onload = function() {
     }
   });
 
-  const textareas = document.getElementsByTagName('textarea');
+  const textareas = document.getElementsByTagName("textarea");
   for (let t of textareas) {
     t.onkeydown = e => {
       if (e.keyCode === 9 || e.which === 9) {
@@ -94,7 +96,7 @@ window.onload = function() {
         const s = this.selectionStart;
         this.value =
           this.value.slice(0, this.selectionStart) +
-          '\t' +
+          "\t" +
           this.value.slice(this.selectionEnd);
         this.selectionEnd = s + 1;
       }
@@ -104,7 +106,7 @@ window.onload = function() {
 
 // Parse URL query parameters
 function getQueryParams(qs) {
-  const query = qs.split('+').join(' '),
+  const query = qs.split("+").join(" "),
     params = {},
     re = /[?&]?([^=]+)=([^&]*)/g;
   let tokens;

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,6 @@
-/* @flow */
+/* @flow strict */
+
+import type { Store as ReduxStore } from 'redux';
 
 // Components
 export type Terminal = {|
@@ -41,15 +43,9 @@ export type File = {|
 |};
 
 // Redux
-export type Store = {
-  getState(): StoreState,
-  +dispatch: Dispatch
-};
+export type Store = ReduxStore<StoreState, Action, Dispatch>;
 
-// TODO: Flow has a bug where exact types become inexact after using the
-// object spread operator. This affects the reducers where the state is spread
-// out, so StoreState is inexact.
-export type StoreState = {
+export type StoreState = {|
   +loaded: boolean,
   +workspaces: Array<Workspace>,
   +wfs: Directory,
@@ -60,7 +56,7 @@ export type StoreState = {
   },
   +selectedWindow: number,
   +selectedWorkspace: number
-};
+|};
 
 export type Dispatch = (action: Action) => void;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @flow strict */
 
 import type { Directory, File, StoreState, Window } from 'types';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,10 @@ const webpack = require('webpack');
 
 const Constants = require('./src/constants.js');
 
+// When adding any global constants via `webpack.definePlugin`,
+// make sure to add its type definition in `flow-typed/mercurywm.js`
+// so flow will understand it.
+
 const config = {
     entry: {
         main: './src/mercury/index.jsx',


### PR DESCRIPTION
Bunch of Flow fixes and updates:

Features:
- Add flow types for `react-redux`, `redux`, MercuryWM constants, `updeep`
- Use strict mode

Bug fixes:
- Flow sometimes not displaying errors properly
  - Add `./src` in `.flowconfig`
- Add explicit prop typing for Redux-connected components
- Combine different props with & instead of spreading