### PR TITLE
Fix missing window select on extensions

### DIFF
--- a/src/mercury/components/root.jsx
+++ b/src/mercury/components/root.jsx
@@ -23,6 +23,7 @@ type StateProps = {|
 |};
 
 type DispatchProps = {|
+    +selectWindowDirect: number => void,
     +selectWorkspace: number => void,
     +selectWindow: number => void,
     +killScript: number => void,
@@ -85,6 +86,10 @@ class Root extends React.Component<Props> {
             case 'writeFile':
                 this.props.createOrModifyFile(message.path, message.content);
                 break;
+            case 'selectWindow':
+                console.log(message);
+                this.props.selectWindowDirect(Number(message.id));
+                break;
         }
     }
 
@@ -98,6 +103,11 @@ const mapStateToProps = (state: StoreState): StateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+    selectWindowDirect: (id: number) =>
+        dispatch({
+            type: 'SELECT_WINDOW',
+            id
+        }),
     selectWorkspace: (direction: number) =>
         dispatch({
             type: 'INTENT_SELECT_WORKSPACE',

--- a/src/mercury/components/root.jsx
+++ b/src/mercury/components/root.jsx
@@ -87,7 +87,6 @@ class Root extends React.Component<Props> {
                 this.props.createOrModifyFile(message.path, message.content);
                 break;
             case 'selectWindow':
-                console.log(message);
                 this.props.selectWindowDirect(Number(message.id));
                 break;
         }

--- a/src/types.js
+++ b/src/types.js
@@ -151,6 +151,10 @@ export type ExtensionMessage =
       +type: 'writeFile',
       +path: string,
       +content: string
+    |}
+  | {|
+      +type: 'selectWindow',
+      +id: string
     |};
 
 // Response message from Mercury to extension


### PR DESCRIPTION
When an extension is clicked, `selectedWindow` is not updated as the click event listener doesn't pick up clicks inside the extension iframe. This results in a few bugs:

- If an extension dispatches an action (via getting env or a file) while a different window is selected, the extension will immediately lose focus
  - Example: editing something in the `todo` extension with an incorrect `selectedWindow` will focus away after one keystroke
- See issue #29

This is fixed by updating `selectedWindow` when a click occurs on the extension iframe.

This must be merged along with https://github.com/wheel-org/mercurywm-scripts/pull/3.