### PR TITLE
mercury: remove tab index

### DIFF
--- a/src/mercury/components/scroll.jsx
+++ b/src/mercury/components/scroll.jsx
@@ -106,7 +106,6 @@ class SmoothScroll extends React.Component<Props> {
       <div
         className="terminal-link"
         ref={this.input}
-        tabIndex="1"
         onKeyDown={this.handleKey}
       >
         {this.props.children}


### PR DESCRIPTION
They're all set to 1 so it doesn't make sense why we have it. Also, it
doesn't actually focus the editor when you tab into it, and it shows an
ugly blue focused line when you click on it.