### PR TITLE
mercury: fix window shift and workspace deletion

### DIFF
--- a/src/background/commands/window/shift.js
+++ b/src/background/commands/window/shift.js
@@ -42,7 +42,7 @@ export default function shift(state: StoreState, params: Array<string>) {
 
   if (result.length !== 0) {
     const change =
-      params[1] === '+' ? 1 : params[1] === '-' ? -1 : parseInt(params[1]);
+      (params[1] === '+' ? 1 : params[1] === '-' ? -1 : parseInt(params[1])) || 0;
 
     const c = getChangeMatrix(params[0], change);
     this.currWindow.x += c[0];

--- a/src/background/commands/workspace.js
+++ b/src/background/commands/workspace.js
@@ -27,13 +27,13 @@ export default function workspace(state: StoreState, params: Array<string>) {
       } else if (state.workspaces.length === 1) {
         this.output('Cannot have zero workspaces');
       } else {
+        state.workspaces.splice(index, 1);
         if (index === state.selectedWorkspace) {
           // $FlowFixMe: command can mutate state
           state.selectedWorkspace = 0;
           // $FlowFixMe: command can mutate state
           state.selectedWindow = state.workspaces[0].windows[0].id;
         }
-        state.workspaces.splice(index, 1);
       }
     } else {
       this.output('Unknown parameter ' + params[0]);


### PR DESCRIPTION
If user doesn't enter anything into window shift, i.e. `window right` without a number, it will entirely destroy the two affected windows. 

We also need to splice the workspace on `workspace delete` before resetting the selected workspace in case the selected workspace to delete is the 0th one.