### PR TITLE
mercurywm: fix no input and still remove outline

### DIFF
--- a/build/main.css
+++ b/build/main.css
@@ -39,6 +39,7 @@ html, body, #root {
     overflow-wrap: break-word;
     overflow-y: scroll;
     overflow-x: visible;
+    outline-width: 0;
 }
 
 .terminal p {

--- a/src/mercury/components/scroll.jsx
+++ b/src/mercury/components/scroll.jsx
@@ -107,6 +107,9 @@ class SmoothScroll extends React.Component<Props> {
         className="terminal-link"
         ref={this.input}
         onKeyDown={this.handleKey}
+        /* tabIndex is needed for onKeyDown to work on a div:
+         * https://stackoverflow.com/questions/43503964/onkeydown-event-not-working-on-divs-in-react */
+        tabIndex="1"
       >
         {this.props.children}
       </div>


### PR DESCRIPTION
Turns out tabindex was needed. Added CSS to remove outline instead.