### PR TITLE
mercurywm: window info padding and size in list

### DIFF
--- a/build/main.css
+++ b/build/main.css
@@ -90,7 +90,7 @@ html, body, #root {
     height: 15px;
     color: #FDFDFD;
     font-size: 8px;
-    padding: 3px;
+    padding: 0px 3px;
 }
 
 .window-frame {

--- a/src/background/commands/window/index.js
+++ b/src/background/commands/window/index.js
@@ -25,8 +25,10 @@ export default function window(state: StoreState, params: Array<string>) {
       return shift.call(this, state, params);
     case 'list':
       this.output('In this workspace:');
-      this.workspace.windows.forEach(({ terminal }, i) => {
+      this.workspace.windows.forEach((window, i) => {
+        const terminal = window.terminal;
         let outputString = '[' + i + '] ';
+        outputString += '(' + window.x + ', ' + window.y + ', ' + window.width + ', ' + window.height + ') ';
         if (terminal.running) {
           outputString +=
             'Running: ' +


### PR DESCRIPTION
Change padding in the window info bottom bar so it doesn't overflow out
of the container, and add window sizes in `window list`