### PR TITLE
mercurywm: fix consistency issue with fast key strokes

### DIFF
--- a/src/background/reducers/index.js
+++ b/src/background/reducers/index.js
@@ -123,6 +123,36 @@ const rootReducer = function(state: StoreState, action: Action): StoreState {
                 selectedWindow: action.id
             };
 
+        case 'INSERT_IN_COMMAND': {
+            const command = currTerminal.history[currTerminal.history.length - 1];
+            const newCommand = command.slice(0, action.insertIndex) + action.text + command.slice(action.insertIndex);
+            return updateCurrTerminal(
+                state,
+                index,
+                u(
+                    {
+                        history: { [action.historyIndex]: newCommand }
+                    },
+                    currTerminal
+                )
+            );
+        }
+
+        case 'DELETE_FROM_COMMAND': {
+            const command = currTerminal.history[currTerminal.history.length - 1];
+            const newCommand = command.slice(0, action.deleteIndex) + command.slice(action.deleteIndex + action.deleteCount);
+            return updateCurrTerminal(
+                state,
+                index,
+                u(
+                    {
+                        history: { [action.historyIndex]: newCommand }
+                    },
+                    currTerminal
+                )
+            );
+        }
+
         case 'UPDATE_COMMAND':
             return updateCurrTerminal(
                 state,

--- a/src/mercury/components/terminal-link.jsx
+++ b/src/mercury/components/terminal-link.jsx
@@ -27,6 +27,8 @@ type StateProps = {|
 
 type DispatchProps = {|
   +updateCommand: (string, number) => void,
+  +insertInCommand: (string, number, number) => void,
+  +deleteFromCommand: (number, number, number) => void,
   +addCommand: (string, boolean) => void,
   +executeCommand: string => void
 |};
@@ -64,12 +66,7 @@ class TerminalLink extends React.Component<Props, State> {
 
   onPaste = (data: string) => {
     const command = this.getCurrentInputCommand();
-    this.props.updateCommand(
-      command.slice(0, this.state.cursor) +
-        data +
-        command.slice(this.state.cursor),
-      this.state.historyIndex
-    );
+    this.props.insertInCommand(data, this.state.historyIndex, this.state.cursor);
     this.setState({
       cursor: this.state.cursor + data.length
     });
@@ -140,11 +137,7 @@ class TerminalLink extends React.Component<Props, State> {
         cursor: command.length
       });
     } else if (e.keyCode === Constants.KEY_BACKSPACE && this.state.cursor > 0) {
-      this.props.updateCommand(
-        command.slice(0, this.state.cursor - 1) +
-          command.slice(this.state.cursor),
-        this.state.historyIndex
-      );
+      this.props.deleteFromCommand(this.state.historyIndex, this.state.cursor - 1, 1);
       this.setState({
         cursor: this.state.cursor - 1
       });
@@ -152,11 +145,7 @@ class TerminalLink extends React.Component<Props, State> {
       e.keyCode === Constants.KEY_DELETE &&
       this.state.cursor < command.length
     ) {
-      this.props.updateCommand(
-        command.slice(0, this.state.cursor) +
-          command.slice(this.state.cursor + 1),
-        this.state.historyIndex
-      );
+      this.props.deleteFromCommand(this.state.historyIndex, this.state.cursor, 1);
     } else if (e.keyCode === Constants.KEY_TAB) {
       const words = command.split(' ');
       if (words.length > 1) {
@@ -210,12 +199,7 @@ class TerminalLink extends React.Component<Props, State> {
         e.preventDefault();
       }
     } else if (e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
-      this.props.updateCommand(
-        command.slice(0, this.state.cursor) +
-          e.key +
-          command.slice(this.state.cursor),
-        this.state.historyIndex
-      );
+      this.props.insertInCommand(e.key, this.state.historyIndex, this.state.cursor);
       this.setState({
         cursor: this.state.cursor + 1
       });
@@ -271,6 +255,22 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
       type: 'ADD_COMMAND',
       text,
       showPrompt
+    });
+  },
+  insertInCommand: (text: string, historyIndex: number, insertIndex: number) => {
+    dispatch({
+      type: 'INSERT_IN_COMMAND',
+      text,
+      historyIndex,
+      insertIndex
+    });
+  },
+  deleteFromCommand: (historyIndex: number, deleteIndex: number, deleteCount: number) => {
+    dispatch({
+      type: 'DELETE_FROM_COMMAND',
+      historyIndex,
+      deleteIndex,
+      deleteCount
     });
   },
   executeCommand: (text: string) => {

--- a/src/types.js
+++ b/src/types.js
@@ -75,6 +75,18 @@ export type Action =
   | {| +type: 'SELECT_WORKSPACE', +id: number |}
   | {| +type: 'SELECT_WINDOW', +id: number |}
   | {| +type: 'UPDATE_COMMAND', +text: string, +index: number |}
+  | {|
+    +type: 'INSERT_IN_COMMAND',
+    +text: string,
+    +historyIndex: number,
+    +insertIndex: number
+  |}
+  | {|
+    +type: 'DELETE_FROM_COMMAND',
+    +historyIndex: number,
+    +deleteIndex: number,
+    +deleteCount: number
+  |}
   | {| +type: 'ADD_COMMAND', +text: string, +showPrompt: boolean |}
   | {| +type: 'EXECUTE_COMMAND', +text: string, +hidden?: boolean |}
   | {|


### PR DESCRIPTION
When the user types fast in the client, we update the cursor
locally, but wait for the server to update the history.

The message sent to the backend contains the full message
which leads to consistency issues because the client doesn't
update fast enough. This commit introduces a single source
of truth (the server), and the client simply sends change
events instead of updating the full string. This means
by the time the server processes all of the changes, and
react updates the client, we get the correct, consistent state.

I think this fixes https://github.com/wheel-org/mercurywm/issues/14 as well, I can't repro it anymore.