### PR TITLE
Fix alias flow

### DIFF
--- a/src/background/commands/alias.js
+++ b/src/background/commands/alias.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-import type { StoreState } from "types";
+import type { StoreState } from 'types';
 
 /* This command has essentially the same logic as env.js */
 export default function alias(state: StoreState, params: Array<string>) {
@@ -11,14 +11,14 @@ export default function alias(state: StoreState, params: Array<string>) {
   if (params.length === 0) {
     Object.keys(state.wsh.aliases).forEach(e => {
       state.wsh.aliases &&
-        this.output(e + ": " + state.wsh.aliases[e], false, false);
+        this.output(e + ': ' + state.wsh.aliases[e], false, false);
     });
   } else if (params.length === 1) {
     if (!state.wsh.aliases[params[0]]) {
       this.output("'" + params[0] + "' is not aliased to anything!");
     } else {
       this.output(
-        params[0] + ": " + state.wsh.aliases[params[0]],
+        params[0] + ': ' + state.wsh.aliases[params[0]],
         false,
         false
       );
@@ -31,7 +31,7 @@ export default function alias(state: StoreState, params: Array<string>) {
       state.wsh.aliases[params[0]] = params[1];
     }
   } else {
-    this.output("Invalid number of parameters");
+    this.output('Invalid number of parameters');
   }
   return state;
 }

--- a/src/background/commands/alias.js
+++ b/src/background/commands/alias.js
@@ -1,31 +1,37 @@
 /* @flow strict */
 
-import type { StoreState } from 'types';
+import type { StoreState } from "types";
 
 /* This command has essentially the same logic as env.js */
 export default function alias(state: StoreState, params: Array<string>) {
   if (!state.wsh.aliases) {
-      state.wsh.aliases = {};
+    // $FlowFixMe: Users with old versions of MercuryWM won't have 'aliases'.
+    state.wsh.aliases = {};
   }
   if (params.length === 0) {
     Object.keys(state.wsh.aliases).forEach(e => {
-        this.output(e + ': ' + state.wsh.aliases[e], false, false);
+      state.wsh.aliases &&
+        this.output(e + ": " + state.wsh.aliases[e], false, false);
     });
   } else if (params.length === 1) {
     if (!state.wsh.aliases[params[0]]) {
-      this.output('\'' + params[0] + '\' is not aliased to anything!');
+      this.output("'" + params[0] + "' is not aliased to anything!");
     } else {
-      this.output(params[0] + ': ' + state.wsh.aliases[params[0]], false, false);
+      this.output(
+        params[0] + ": " + state.wsh.aliases[params[0]],
+        false,
+        false
+      );
     }
   } else if (params.length === 2) {
-    // $FlowFixMe: command can mutate state
     if (!params[1]) {
       delete state.wsh.aliases[params[0]];
     } else {
+      // $FlowFixMe: command can mutate state
       state.wsh.aliases[params[0]] = params[1];
     }
   } else {
-    this.output('Invalid number of parameters');
+    this.output("Invalid number of parameters");
   }
   return state;
 }

--- a/src/background/commands/index.js
+++ b/src/background/commands/index.js
@@ -23,7 +23,8 @@ function Command(state, command, params) {
             prompt: showPrompt ? this.terminal.workingDirectory : ''
         });
     };
-    this.traversePath = function(directory, parts, callback) {
+    this.traversePath = function(dir, parts, callback) {
+        let directory = dir;
         while (parts.length > 0 && parts[0] === '~') {
             // Remove root directory
             parts.shift();

--- a/src/types.js
+++ b/src/types.js
@@ -52,6 +52,9 @@ export type StoreState = {|
   +wsh: {
     +env: {
       +[string]: string
+    },
+    +aliases?: {
+      +[string]: string
     }
   },
   +selectedWindow: number,


### PR DESCRIPTION
Fixing Flow errors from adding aliases. After this commit, the codebase should be free of Flow errors.

Also, in `Command.traversePath`, the argument `directory` was being modified, resulting in a readonly error. This short fix is to copy the argument into a editable variable.