### PR TITLE
State updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3073,7 +3073,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3094,12 +3095,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3114,17 +3117,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3241,7 +3247,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3253,6 +3260,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3267,6 +3275,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3274,12 +3283,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3298,6 +3309,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3378,7 +3390,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3390,6 +3403,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3475,7 +3489,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3511,6 +3526,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3530,6 +3546,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3573,12 +3590,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mercurywm",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "New tab page with multi-windowed terminals",
     "main": "src/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mercurywm",
-    "version": "2.1.0",
+    "version": "2.0.0",
     "description": "New tab page with multi-windowed terminals",
     "main": "src/index.js",
     "scripts": {

--- a/src/background/commands/alias.js
+++ b/src/background/commands/alias.js
@@ -4,14 +4,9 @@ import type { StoreState } from 'types';
 
 /* This command has essentially the same logic as env.js */
 export default function alias(state: StoreState, params: Array<string>) {
-  if (!state.wsh.aliases) {
-    // $FlowFixMe: Users with old versions of MercuryWM won't have 'aliases'.
-    state.wsh.aliases = {};
-  }
   if (params.length === 0) {
     Object.keys(state.wsh.aliases).forEach(e => {
-      state.wsh.aliases &&
-        this.output(e + ': ' + state.wsh.aliases[e], false, false);
+      this.output(e + ': ' + state.wsh.aliases[e], false, false);
     });
   } else if (params.length === 1) {
     if (!state.wsh.aliases[params[0]]) {

--- a/src/background/reducers/index.js
+++ b/src/background/reducers/index.js
@@ -13,6 +13,7 @@ import {
     getDirectory,
     getFile
 } from 'utils';
+import updater from './updater';
 
 import type { Action, Directory, StoreState, Terminal } from 'types';
 
@@ -84,7 +85,7 @@ const rootReducer = function(state: StoreState, action: Action): StoreState {
     switch (action.type) {
         case 'LOAD_STORAGE':
             return {
-                ...action.data,
+                ...updater(action.data),
                 loaded: true
             };
 

--- a/src/background/reducers/updater.js
+++ b/src/background/reducers/updater.js
@@ -10,7 +10,7 @@ const updates = {
     u(
       {
         wsh: {
-          aliases: {}
+          aliases: aliases => (typeof aliases === 'object' ? aliases : {})
         }
       },
       state
@@ -19,9 +19,9 @@ const updates = {
 
 // List of all version strings
 // The last version in the list must be the current version in package.json
-const versions = ['1.0.0', '1.1.0', '2.0.0'];
+const versions = ['1.0.0', '1.1.0', '2.0.0', '2.0.1'];
 
-function updateState(state: StoreState): StoreState {
+export default function updateState(state: StoreState): StoreState {
   let index = versions.findIndex(v => v === state.version);
   // Invalid version string; try all updates
   if (index === -1) {
@@ -37,6 +37,8 @@ function updateState(state: StoreState): StoreState {
       state = update(state);
     }
 
+    // There may be an update applied during the latest version (during development).
+    // Since the next version string isn't set, keep the version string the same.
     if (state.version !== Constants.VERSION) {
       // $FlowFixMe: mutating state
       state.version = versions[index + 1];

--- a/src/background/reducers/updater.js
+++ b/src/background/reducers/updater.js
@@ -1,0 +1,42 @@
+/* @flow strict */
+
+import type { StoreState } from 'types';
+
+const updates = {
+  '2.0.0': state => ({
+    ...state,
+    aliases: {}
+  })
+};
+
+// List of all version strings
+const versions = ['1.0.0', '1.1.0', '2.0.0', '2.1.0'];
+
+function updateState(state: $Shape<StoreState>): StoreState {
+  // Missing version string; try all updates
+  if (!state.version) {
+    // $FlowFixMe: mutating state
+    state.version = '1.0.0';
+  }
+
+  // While the state isn't updated to the latest version, keep applying updates
+  while (state.version !== Constants.VERSION) {
+    const index = versions.findIndex(v => v === state.version);
+    if (index === -1) {
+      // Invalid version string; try all updates
+      // $FlowFixMe: mutating state
+      state.version = '1.0.0';
+    } else {
+      const update = updates[state.version];
+      if (update) {
+        // $FlowFixMe: mutating state
+        state = update(state);
+      }
+
+      // $FlowFixMe: mutating state
+      state.version = versions[index + 1];
+    }
+  }
+
+  return state;
+}

--- a/src/background/reducers/updater.js
+++ b/src/background/reducers/updater.js
@@ -13,12 +13,6 @@ const updates = {
 const versions = ['1.0.0', '1.1.0', '2.0.0', '2.1.0'];
 
 function updateState(state: $Shape<StoreState>): StoreState {
-  // Missing version string; try all updates
-  if (!state.version) {
-    // $FlowFixMe: mutating state
-    state.version = '1.0.0';
-  }
-
   // While the state isn't updated to the latest version, keep applying updates
   while (state.version !== Constants.VERSION) {
     const index = versions.findIndex(v => v === state.version);

--- a/src/background/reducers/updater.js
+++ b/src/background/reducers/updater.js
@@ -1,35 +1,48 @@
 /* @flow strict */
 
+import u from 'updeep';
+
 import type { StoreState } from 'types';
 
+// Updates should be safe to perform even for updated users
 const updates = {
-  '2.0.0': state => ({
-    ...state,
-    aliases: {}
-  })
+  '2.0.0': (state: StoreState) =>
+    u(
+      {
+        wsh: {
+          aliases: {}
+        }
+      },
+      state
+    )
 };
 
 // List of all version strings
-const versions = ['1.0.0', '1.1.0', '2.0.0', '2.1.0'];
+// The last version in the list must be the current version in package.json
+const versions = ['1.0.0', '1.1.0', '2.0.0'];
 
-function updateState(state: $Shape<StoreState>): StoreState {
-  // While the state isn't updated to the latest version, keep applying updates
-  while (state.version !== Constants.VERSION) {
-    const index = versions.findIndex(v => v === state.version);
-    if (index === -1) {
-      // Invalid version string; try all updates
+function updateState(state: StoreState): StoreState {
+  let index = versions.findIndex(v => v === state.version);
+  // Invalid version string; try all updates
+  if (index === -1) {
+    // $FlowFixMe: mutating state
+    state.version = '1.0.0';
+  }
+
+  // Keep applying updaters until the state is at the latest version
+  while (index < versions.length) {
+    const update = updates[state.version];
+    if (update) {
       // $FlowFixMe: mutating state
-      state.version = '1.0.0';
-    } else {
-      const update = updates[state.version];
-      if (update) {
-        // $FlowFixMe: mutating state
-        state = update(state);
-      }
+      state = update(state);
+    }
 
+    if (state.version !== Constants.VERSION) {
       // $FlowFixMe: mutating state
       state.version = versions[index + 1];
     }
+
+    index++;
   }
 
   return state;

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -12,7 +12,10 @@ export const initialState = {
   loaded: false,
   workspaces: [createWorkspace(id)],
   wfs: createDirectory('~', [
-    createFile('Welcome', 'Welcome to MercuryWM! Type `setup` to get started!\n'),
+    createFile(
+      'Welcome',
+      'Welcome to MercuryWM! Type `setup` to get started!\n'
+    ),
     createDirectory('.bin', [createFile('setup', setupFile)])
   ]),
   wsh: {
@@ -22,16 +25,18 @@ export const initialState = {
       title: '',
       prompt: '%w $ ',
       username: Constants.NAME
-    }
+    },
+    aliases: {}
   },
   selectedWindow: id,
-  selectedWorkspace: 0
+  selectedWorkspace: 0,
+  version: Constants.VERSION
 };
 const defaultStateObject: StorageState = {
   [Constants.STATE_KEY]: initialState
 };
 
-export function load(callback: StoreState => void) {
+export function load(callback: any => void) {
   chrome.storage.local.get(defaultStateObject, (data: StorageState) => {
     callback(data[Constants.STATE_KEY]);
   });

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -36,7 +36,7 @@ const defaultStateObject: StorageState = {
   [Constants.STATE_KEY]: initialState
 };
 
-export function load(callback: any => void) {
+export function load(callback: StoreState => void) {
   chrome.storage.local.get(defaultStateObject, (data: StorageState) => {
     callback(data[Constants.STATE_KEY]);
   });

--- a/src/mercury/store.js
+++ b/src/mercury/store.js
@@ -13,14 +13,19 @@ const defaultStateObject: StorageState = {
     workspaces: [],
     wfs: createDirectory('~', []),
     wsh: {
-      env: {}
+      env: {},
+      aliases: {}
     },
     selectedWindow: 0,
-    selectedWorkspace: 0
+    selectedWorkspace: 0,
+    version: ''
   }
 };
 
-const store: Store = createStore(reducer, defaultStateObject[Constants.STATE_KEY]);
+const store: Store = createStore(
+  reducer,
+  defaultStateObject[Constants.STATE_KEY]
+);
 
 chrome.storage.local.get(Constants.STATE_KEY, (data: StorageState) => {
   store.dispatch({

--- a/src/types.js
+++ b/src/types.js
@@ -53,12 +53,13 @@ export type StoreState = {|
     +env: {
       +[string]: string
     },
-    +aliases?: {
+    +aliases: {
       +[string]: string
     }
   },
   +selectedWindow: number,
-  +selectedWorkspace: number
+  +selectedWorkspace: number,
+  +version: string
 |};
 
 export type Dispatch = (action: Action) => void;
@@ -79,17 +80,17 @@ export type Action =
   | {| +type: 'SELECT_WINDOW', +id: number |}
   | {| +type: 'UPDATE_COMMAND', +text: string, +index: number |}
   | {|
-    +type: 'INSERT_IN_COMMAND',
-    +text: string,
-    +historyIndex: number,
-    +insertIndex: number
-  |}
+      +type: 'INSERT_IN_COMMAND',
+      +text: string,
+      +historyIndex: number,
+      +insertIndex: number
+    |}
   | {|
-    +type: 'DELETE_FROM_COMMAND',
-    +historyIndex: number,
-    +deleteIndex: number,
-    +deleteCount: number
-  |}
+      +type: 'DELETE_FROM_COMMAND',
+      +historyIndex: number,
+      +deleteIndex: number,
+      +deleteCount: number
+    |}
   | {| +type: 'ADD_COMMAND', +text: string, +showPrompt: boolean |}
   | {| +type: 'EXECUTE_COMMAND', +text: string, +hidden?: boolean |}
   | {|


### PR DESCRIPTION
Resolves #65 

If a new version changes the shape of the state, we need to make sure any existing users' states will also be updated accordingly. To perform this patch, we create "updaters".

An updater is a function that accepts the state, modifies a certain part of the state, and returns it. Then, we can write an updater whenever there is a difference in state shape between two versions.

The new file `updater.js` will take the current version of the state, and perform updaters until it becomes up to date. These updates will only occur when the Background loads up. For users, this will only happen if MercuryWM is reloaded, reinstalled, or updated (automatically by Chrome).